### PR TITLE
Fix format string vulnerabilities and creature examination %s bug

### DIFF
--- a/src/game/gdialog.cc
+++ b/src/game/gdialog.cc
@@ -614,7 +614,7 @@ void gdialog_enter(Object* target, int a2)
                 if (a2) {
                     display_print(messageListItem.text);
                 } else {
-                    debug_printf(messageListItem.text);
+                    debug_printf("%s", messageListItem.text);
                 }
             } else {
                 debug_printf("\nError: gdialog: Can't find message!");
@@ -629,7 +629,7 @@ void gdialog_enter(Object* target, int a2)
                 if (a2) {
                     display_print(messageListItem.text);
                 } else {
-                    debug_printf(messageListItem.text);
+                    debug_printf("%s", messageListItem.text);
                 }
             } else {
                 debug_printf("\nError: gdialog: Can't find message!");

--- a/src/game/protinst.cc
+++ b/src/game/protinst.cc
@@ -391,7 +391,7 @@ int obj_examine_func(Object* critter, Object* target, void (*fn)(char* string))
                     exit(1);
                 }
 
-                debug_printf(hpMessageListItem.text);
+                debug_printf("%s", hpMessageListItem.text);
                 return 0;
             }
 
@@ -404,15 +404,11 @@ int obj_examine_func(Object* critter, Object* target, void (*fn)(char* string))
                     exit(1);
                 }
 
+                debug_printf("\nDEBUG: v66.text (msg %d): '%s'\n", v66.num, v66.text);
+                debug_printf("\nDEBUG: hpMessageListItem.text (msg %d): '%s'\n", hpMessageListItem.num, hpMessageListItem.text);
                 snprintf(formattedText, sizeof(formattedText), v66.text, hpMessageListItem.text);
             } else {
-                // %s %s
-                v66.num = 521 + v12;
-                if (!message_search(&proto_main_msg_file, &v66)) {
-                    debug_printf("\nError: Can't find msg num!");
-                    exit(1);
-                }
-
+                // He/She looks: %s (message 522/523 already contains the pronoun and format)
                 MessageListItem v63;
                 v63.num = 522 + stat_level(target, STAT_GENDER);
                 if (!message_search(&proto_main_msg_file, &v63)) {
@@ -420,7 +416,9 @@ int obj_examine_func(Object* critter, Object* target, void (*fn)(char* string))
                     exit(1);
                 }
 
-                snprintf(formattedText, sizeof(formattedText), v66.text, v63.text, hpMessageListItem.text);
+                debug_printf("\nDEBUG: v63.text (msg %d): '%s'\n", v63.num, v63.text);
+                debug_printf("\nDEBUG: hpMessageListItem.text (msg %d): '%s'\n", hpMessageListItem.num, hpMessageListItem.text);
+                snprintf(formattedText, sizeof(formattedText), v63.text, hpMessageListItem.text);
             }
         }
 
@@ -965,7 +963,7 @@ static int protinst_default_use_item(Object* a1, Object* a2, Object* item)
 
     messageListItem.num = 582;
     if (message_search(&proto_main_msg_file, &messageListItem)) {
-        snprintf(formattedText, sizeof(formattedText), messageListItem.text);
+        snprintf(formattedText, sizeof(formattedText), "%s", messageListItem.text);
         display_print(formattedText);
     }
     return -1;

--- a/src/game/skill.cc
+++ b/src/game/skill.cc
@@ -481,7 +481,7 @@ int skill_use(Object* obj, Object* a2, int skill, int criticalChanceModifier)
             // 514: It's dead, get over it.
             messageListItem.num = 512 + roll_random(0, 2);
             if (message_search(&skill_message_file, &messageListItem)) {
-                debug_printf(messageListItem.text);
+                debug_printf("%s", messageListItem.text);
             }
 
             break;
@@ -760,7 +760,7 @@ int skill_use(Object* obj, Object* a2, int skill, int criticalChanceModifier)
         // skill_use: invalid skill used.
         messageListItem.num = 510;
         if (message_search(&skill_message_file, &messageListItem)) {
-            debug_printf(messageListItem.text);
+            debug_printf("%s", messageListItem.text);
         }
 
         return -1;

--- a/src/int/audio.cc
+++ b/src/int/audio.cc
@@ -61,7 +61,7 @@ static unsigned int decodeRead(void* stream, void* buffer, unsigned int size)
 int audioOpen(const char* fname, int flags)
 {
     char path[80];
-    snprintf(path, sizeof(path), fname);
+    snprintf(path, sizeof(path), "%s", fname);
 
     int compression;
     if (queryCompressedFunc(path)) {


### PR DESCRIPTION
Made by @IrishAdo, it fix the %s Examination Text bug, it also fix the unability to compile on Linux as cited by @dje4321 . 

- Fixed creature examination showing 'He looks: %s. Wounded.' instead of 'He looks: Wounded.'
- Removed unnecessary message 521 lookup in favor of direct use of messages 522/523
- Fixed format string security vulnerabilities in snprintf and debug_printf calls
- Added '%s' format specifiers to prevent potential security issues
- Updated protinst.cc, gdialog.cc, skill.cc, and audio.cc