### PR TITLE
Add distro-specific instructions for installing SDL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,22 @@ $ mv app Fallout
 - Download and copy `fallout-ce` to this folder.
 
 - Install [SDL2](https://libsdl.org/download-2.0.php):
-
+#### Debian-based distros
 ```console
 $ sudo apt install libsdl2-2.0-0
 ```
-
+#### Arch-based distros
+```console
+$ sudo pacman -S sdl2-compat
+```
+#### Gentoo-based distros
+```console
+$ sudo emerge -a libsdl2
+```
+#### Fedora/RPM-based distros
+```console
+$ sudo dnf install SDL2
+```
 - Run `./fallout-ce`.
 
 ### macOS


### PR DESCRIPTION
Arch Linux for instance uses the sdl2-compat package as sdl2 is no longer available on the repos.