### PR TITLE
fix: enable DEBUGACTIVE so debug.log is actually created

### DIFF
--- a/src/plib/gnw/debug.cc
+++ b/src/plib/gnw/debug.cc
@@ -36,6 +36,10 @@ static DebugFunc* debug_func = NULL;
 void GNW_debug_init()
 {
     atexit(debug_exit);
+
+    // Original game enabled this via DEBUGACTIVE; CE never called it, so
+    // `$env:DEBUGACTIVE="log"` produced no debug.log.
+    debug_register_env();
 }
 
 // 0x4B2D9C
@@ -58,9 +62,12 @@ void debug_register_log(const char* fileName, const char* mode)
     if ((mode[0] == 'w' || mode[0] == 'a') && mode[1] == 't') {
         if (fd != NULL) {
             fclose(fd);
+            fd = NULL;
         }
 
         fd = compat_fopen(fileName, mode);
+
+        // Still attach the logger even if open failed so Debug SDL_Log path stays unused.
         debug_func = debug_log;
     }
 }


### PR DESCRIPTION
## Summary
- Call `debug_register_env()` from `GNW_debug_init()` so `DEBUGACTIVE` works again.

## Error
Setting `DEBUGACTIVE=log` (Windows: `$env:DEBUGACTIVE=log`) never created `debug.log`. `debug_printf` kept going to the SDL log path instead of a file.

**Cause:** `GNW_debug_init()` registered `atexit` cleanup but never called `debug_register_env()`, so the env-based backends (`mono` / `log` / `screen` / `gnw`) were never attached.

Also clears the previous log `FILE*` after close and keeps the log handler attached even if `fopen` fails, so debug output does not silently fall back to SDL.

## Test plan
- [x] Build with this change
- [x] Set `DEBUGACTIVE=log` and launch the game
- [x] Confirm `debug.log` is created and receives debug output
- [x] Confirm unset `DEBUGACTIVE` still does not create a log file