### PR TITLE
Fix cross-elevation combat on multi-level maps

### DIFF
--- a/src/game/combat.cc
+++ b/src/game/combat.cc
@@ -2401,9 +2401,13 @@ static bool combat_should_end()
 // 0x420B20
 void combat(CombatStartData* csd)
 {
+    // Both participants (when present) must be on the current elevation.
+    // The original OR allowed e.g. a rat on elev 2 to start combat against the
+    // player on elev 0 — combat then runs with an off-floor attacker that is
+    // never rendered ("invisible enemies"), common in multi-store levels like Vault 15.
     if (csd == NULL
-        || (csd->attacker == NULL || csd->attacker->elevation == map_elevation)
-        || (csd->defender == NULL || csd->defender->elevation == map_elevation)) {
+        || ((csd->attacker == NULL || csd->attacker->elevation == map_elevation)
+            && (csd->defender == NULL || csd->defender->elevation == map_elevation))) {
         bool wasInCombat = (combat_state & 0x01) != 0;
 
         combat_begin(NULL);

--- a/src/game/combatai.cc
+++ b/src/game/combatai.cc
@@ -1591,6 +1591,13 @@ bool is_within_perception(Object* critter1, Object* critter2)
     int perception;
     int max_distance;
 
+    // Elevations share one hex grid, so obj_dist is elevation-blind. Without
+    // this, critters on other Vault floors can "perceive" the player when their
+    // tile numbers happen to be nearby (e.g. elev 2 rat vs elev 0 dude).
+    if (critter1->elevation != critter2->elevation) {
+        return false;
+    }
+
     distance = obj_dist(critter2, critter1);
     perception = stat_level(critter1, STAT_PERCEPTION);
     if (can_see(critter1, critter2)) {

--- a/src/int/support/intextra.cc
+++ b/src/int/support/intextra.cc
@@ -1485,6 +1485,15 @@ static void op_attack(Program* program)
         return;
     }
 
+    // Critter scripts run for every elevation; without this, rats on other
+    // floors can attack the player on the current floor.
+    if (self->elevation != target->elevation || self->elevation != map_elevation) {
+        dbg_print_com_data(self, target);
+        debug_printf("\n   But attacker/target are on different elevation (ignored)");
+        program->flags &= ~PROGRAM_FLAG_0x20;
+        return;
+    }
+
     if (!critter_is_active(self)) {
         dbg_print_com_data(self, target);
         debug_printf("\n   But is already Inactive (Dead/Stunned)");
@@ -3702,6 +3711,15 @@ static void op_attack_setup(Program* program)
     program->flags |= PROGRAM_FLAG_0x20;
 
     if (attacker != NULL) {
+        if (defender == NULL
+            || attacker->elevation != defender->elevation
+            || attacker->elevation != map_elevation) {
+            dbg_print_com_data(attacker, defender);
+            debug_printf("\n   But attacker/target are on different elevation (ignored)");
+            program->flags &= ~PROGRAM_FLAG_0x20;
+            return;
+        }
+
         if (!critter_is_active(attacker)) {
             dbg_print_com_data(attacker, defender);
             debug_printf("\n   But is already dead");


### PR DESCRIPTION
## Summary

Closes #10 (self-attack / invisible combat on multi-elevation maps such as Vault 15, Necropolis Watershed, The Glow).

### Bug

Fallout 1 maps share one hex grid across elevations. Critter scripts still run on **every** floor (`script_chk_critters`), and `obj_dist` / `tile_dist` ignore elevation. An enemy on another floor can therefore sit a few hexes away in tile math, pass perception / call `attack(dude)`, and start combat.

`combat()` previously used an **OR** check: combat started if *either* attacker or defender was on `map_elevation`. With the player on elev 0, an elev-2 enemy was enough to begin a fight. `combat_begin` then builds the cast from the **current** floor only, so you get a real encounter among visible enemies/companions triggered by an off-floor requester you cannot see or hit.

Example from debug logs on Vault 15:

```
Scripts [Combat]: Pig Rat(Team 9) requests attack on Dude(Team 0)
Attacker: elev=2/0 dist=5
Defender: elev=0
COMBAT_BEGIN[...]: all participants elev=0
```

(`elev=2/0` = attacker elevation 2 vs `map_elevation` 0.)

### Fix (three layers)

1. **`combatai.cc` — `is_within_perception`**  
   Require same elevation. Stops false `obj_can_see_obj` across floors (shared hex grid + elevation-blind distance).

2. **`intextra.cc` — `op_attack` / `op_attack_setup`**  
   Ignore scripted attacks when attacker/target elevations differ or attacker is not on `map_elevation`. Covers scripts that call `attack()` without a see check (hostility flags, damage procs, etc.).

3. **`combat.cc` — `combat()` entry**  
   Change participant elevation check from **OR** to **AND**: both attacker and defender (when present) must be on `map_elevation`. Hard stop so leftover requests cannot start a haunted floor-0 fight.

### Notes

- Mid-combat join already rejected other elevations (`combatai_want_to_join`).
- Same-floor combat and intentional same-elev scripted attacks are unchanged.

## IMPORTANT
I did testing only on Vault 15 level and on couple of normal levels with only one elevation level, but it should work also on Necropolis Watershed and The Glow

## Test plan

- [x] Vault 15: walk floor 0 near stacked elev 1/2 rat areas - combat must not start from off-floor scripts
- [x] Vault 15: start and finish a normal same-floor fight; AI targeting and scripted aggro still work
- [x] Confirm companions/party combat on the current elevation still initiates correctly